### PR TITLE
Load macros before service template

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub fn run<T, U>(services_path: T, output_dir: U) -> Result<()>
 {
     // Compile templates
     let mut templates = tera::Tera::default();
-    templates.add_raw_template("service.rs",  include_str!("../templates/service.rs.tera")).unwrap();
     templates.add_raw_template("macros.tera", include_str!("../templates/macros.tera")).unwrap();
+    templates.add_raw_template("service.rs",  include_str!("../templates/service.rs.tera")).unwrap();
 
     let services_path : &Path = services_path.as_ref();
     let output_dir    : &Path = output_dir.as_ref();


### PR DESCRIPTION
Hi Cahu, thanks for putting together a Rust client for kRPC. I had to make this and one other edit to get it building; submitting pull requests for both if you're interested.

Re:
```
 Error(Msg("Template `service.rs` loads macros from `macros.tera` which isn\'t present in Tera")
```